### PR TITLE
Editing devcontainer and qiskit.txt

### DIFF
--- a/.devcontainer/qiskit/devcontainer.json
+++ b/.devcontainer/qiskit/devcontainer.json
@@ -1,7 +1,7 @@
 {
   "image": "mcr.microsoft.com/devcontainers/python:3.12-bullseye",
   "waitFor": "onCreateCommand",
-  "updateContentCommand": "python3 -m pip install -r Requirements/qiskit.txt",
+  "updateContentCommand": "/usr/bin/python3 -m pip install -r Requirements/qiskit.txt && /usr/local/bin/python3 -m pip install -r Requirements/qiskit.txt",
   "postCreateCommand": "",
   "features": {
     "ghcr.io/devcontainers/features/github-cli:1": {},

--- a/Requirements/qiskit.txt
+++ b/Requirements/qiskit.txt
@@ -1,5 +1,6 @@
 numpy
 pandas
+ipykernel
 qiskit[visualization]
 qiskit-aer
 qiskit-ibm-provider


### PR DESCRIPTION
These edits allow codespaces on vscode to run on startup with no need for manual installations by specifying the locations of the initial setup in the devcontainer.json. 

They also allow the codespace to use other interpreters than the python 3.9 interpreter which worked. This includes the python 3.12 interpreters.

I created a few entirely fresh codespaces to test, and with these two changes these has been absolutely no issues on startup, and it can create a Jupyter file, import qiskit, and run code with no issues.