### PR TITLE
Typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Also use discord for discussing solutions to any issues popping up.
 | Closed Issues                    | 6              | $\frac 1 3$  | 2          |
 | \# Conversations                 | 25             | $\frac 1 5$  | 5          |
 |                                  |                |              |            |
-| Total                            | 43             |              | 16         |
+| Total                            | 44             |              | 16         |
 |                                  |                |              |            |
 | Shared project points            |                |              |            |
 | \# Label                         | 8              | $\frac 1 2$  | 4          |


### PR DESCRIPTION
Changed total in line 49 from 43 to 44

(edit) how do I directly reference the line in the code?

https://github.com/ubsuny/CP1-24-HW1/blob/f93f60a6159201ce8972bd381bf4d15de9e7b6cb/README.md?plain=1#L49