### PR TITLE
Documented the Mathematics of Bell's Inequality

### DIFF
--- a/Mathematics_Bells_Inequality.md
+++ b/Mathematics_Bells_Inequality.md
@@ -1,0 +1,33 @@
+# Bell's Inequality Documentation
+
+## Introduction
+Bell's inequality is a crucial test in quantum mechanics that distinguishes between quantum mechanical predictions and classical physics assumptions, particularly local hidden variable theories.
+
+## Key Concepts
+
+-Local Hidden Variable Theories: Assume that the properties of particles are determined by hidden variables and are not influenced by actions at a distance.
+-Quantum Entanglement: A phenomenon where two particles remain interconnected, such that the state of one directly affects the state of the other, regardless of the distance between them.
+
+## Mathematical Derivation of Bell's Inequality
+
+To understand Bell's inequality, consider two entangled particles measured by observers Alice and Bob with different settings. The expectation value of their measurements is given by:
+
+$$ E(a, b) = \int d\lambda \, \rho(\lambda) A(a, \lambda) B(b, \lambda) $$
+
+where:
+- \( A(a, \lambda) \) and \( B(b, \lambda) \) represent measurement outcomes.
+- \( \rho(\lambda) \) is the probability distribution of hidden variables.
+
+ ## Derivation
+
+1. The expectation value of the product of Alice's and Bob's outcomes for a given pair of settings \( (a, b) \) is defined as:
+
+   $$ E(a, b) = \int d\lambda \, \rho(\lambda) A(a, \lambda) B(b, \lambda) $$
+
+2. Combine expectation values to form the inequality:
+
+   $$ S = E(a, b) - E(a, b') + E(a', b) + E(a', b') $$
+
+3. Under local hidden variable assumptions, we derive:
+
+   $$ |S| \leq 2 $$

--- a/Mathematics_Bells_Inequality.md
+++ b/Mathematics_Bells_Inequality.md
@@ -27,28 +27,22 @@ $$ E(a, b) = \int d\lambda \, \rho(\lambda) A(a, \lambda) B(b, \lambda) $$
 
 where:
 ## Definition of Variables
-- '\( A(a, \lambda) \)' and '\( B(b, \lambda) \)' represent measurement outcomes.
-- '\( \rho(\lambda) \)' is the probability distribution of hidden variables.
+- `$A(a, \lambda)$` and `$B(b, \lambda)$` represent measurement outcomes.
+- `$ \rho(\lambda)$` is the probability distribution of hidden variables.
 
 ## Derivation
 
 1. The expectation value of the product of Alice's and Bob's outcomes for a given pair of settings \( (a, b) \) is defined as:
 
-   $$
-   E(a, b) = \int d\lambda \, \rho(\lambda) A(a, \lambda) B(b, \lambda)
-   $$
+   $$ E(a, b) = \int d\lambda \, \rho(\lambda) A(a, \lambda) B(b, \lambda) $$
 
 2. Combine expectation values to form the inequality:
 
-   $$
-   S = E(a, b) - E(a, b') + E(a', b) + E(a', b')
-   $$
+   $$ S = E(a, b) - E(a, b') + E(a', b) + E(a', b') $$
 
 3. Under local hidden variable assumptions, we derive:
 
-   $$
-   |S| \leq 2
-   $$
+   $$ |S| \leq 2 $$
 
 ### Referances 
 1. https://cds.cern.ch/record/111654/files/vol1p195-200_001.pdf

--- a/Mathematics_Bells_Inequality.md
+++ b/Mathematics_Bells_Inequality.md
@@ -4,9 +4,20 @@
 Bell's inequality is a crucial test in quantum mechanics that distinguishes between quantum mechanical predictions and classical physics assumptions, particularly local hidden variable theories.
 
 ## Key Concepts
+- Local Hidden Variable Theories: Assume that the properties of particles are determined by hidden variables and are not influenced by actions at a distance. Local Hidden Variable   theories offer a classical way to explain measurement outcomes by assuming that hidden variables determine the results, respecting locality and realism.
+- Quantum Entanglement: A phenomenon where two particles remain interconnected, such that the state of one directly affects the state of the other, regardless of the distance between them. # Quantum Entanglement in the Context of Bell’s Inequality
 
--Local Hidden Variable Theories: Assume that the properties of particles are determined by hidden variables and are not influenced by actions at a distance.
--Quantum Entanglement: A phenomenon where two particles remain interconnected, such that the state of one directly affects the state of the other, regardless of the distance between them.
+Consider two quantum particles, often referred to as qubits, in an entangled state. A common example of an entangled state used in Bell’s inequality tests is the **Bell state**, also known as the singlet state:
+
+$$
+|\psi\rangle = \frac{1}{\sqrt{2}} (|01\rangle - |10\rangle)
+$$
+
+This state describes two qubits, where:
+- \(|01\rangle\): The first qubit is in state \( |0\rangle \) (e.g., spin down), and the second is in state \( |1\rangle \) (e.g., spin up).
+- \(|10\rangle\): The first qubit is in state \( |1\rangle \) (spin up), and the second is in state \( |0\rangle \) (spin down).
+
+The overall state is a superposition where the particles are perfectly anti-correlated, meaning that if one particle is measured to be \( |0\rangle \), the other will definitely be \( |1\rangle \), and vice versa.
 
 ## Mathematical Derivation of Bell's Inequality
 
@@ -15,19 +26,29 @@ To understand Bell's inequality, consider two entangled particles measured by ob
 $$ E(a, b) = \int d\lambda \, \rho(\lambda) A(a, \lambda) B(b, \lambda) $$
 
 where:
-- \( A(a, \lambda) \) and \( B(b, \lambda) \) represent measurement outcomes.
-- \( \rho(\lambda) \) is the probability distribution of hidden variables.
+## Definition of Variables
+- '\( A(a, \lambda) \)' and '\( B(b, \lambda) \)' represent measurement outcomes.
+- '\( \rho(\lambda) \)' is the probability distribution of hidden variables.
 
- ## Derivation
+## Derivation
 
 1. The expectation value of the product of Alice's and Bob's outcomes for a given pair of settings \( (a, b) \) is defined as:
 
-   $$ E(a, b) = \int d\lambda \, \rho(\lambda) A(a, \lambda) B(b, \lambda) $$
+   $$
+   E(a, b) = \int d\lambda \, \rho(\lambda) A(a, \lambda) B(b, \lambda)
+   $$
 
 2. Combine expectation values to form the inequality:
 
-   $$ S = E(a, b) - E(a, b') + E(a', b) + E(a', b') $$
+   $$
+   S = E(a, b) - E(a, b') + E(a', b) + E(a', b')
+   $$
 
 3. Under local hidden variable assumptions, we derive:
 
-   $$ |S| \leq 2 $$
+   $$
+   |S| \leq 2
+   $$
+
+### Referances 
+1. https://cds.cern.ch/record/111654/files/vol1p195-200_001.pdf

--- a/Mathematics_Bells_Inequality.md
+++ b/Mathematics_Bells_Inequality.md
@@ -14,8 +14,8 @@ $$
 $$
 
 This state describes two qubits, where:
-- \(|01\rangle\): The first qubit is in state \(|0\rangle\) (e.g., spin down), and the second is in state \(|1\rangle\) (e.g., spin up).
-- \(|10\rangle\): The first qubit is in state \(|1\rangle\) (spin up), and the second is in state \(|0\rangle\) (spin down).
+\(|01\rangle\): The first qubit is in state \(|0\rangle\) (e.g., spin down), and the second is in state \(|1\rangle\) (e.g., spin up).
+\(|10\rangle\): The first qubit is in state \(|1\rangle\) (spin up), and the second is in state \(|0\rangle\) (spin down).
 
 The overall state is a superposition where the particles are perfectly anti-correlated.
 
@@ -26,28 +26,26 @@ To understand Bell's inequality, consider two entangled particles measured by ob
 $$ E(a, b) = \int d\lambda \, \rho(\lambda) A(a, \lambda) B(b, \lambda) $$
 
 where:
-- `$A(a, \lambda)$` and `$B(b, \lambda)$` represent measurement outcomes.
-- `$\rho(\lambda)$` is the probability distribution of hidden variables.
+`$A(a, \lambda)$` and `$B(b, \lambda)$` represent measurement outcomes.
+`$\rho(\lambda)$` is the probability distribution of hidden variables.
 
 ## Derivation
 
-1. The expectation value of the product of Alice's and Bob's outcomes for a given pair of settings \( (a, b) \) is defined as:
+The expectation value of the product of Alice's and Bob's outcomes for a given pair of settings \( (a, b) \) is defined as:
+ $$
+ E(a, b) = \int d\lambda \, \rho(\lambda) A(a, \lambda) B(b, \lambda)
+ $$
 
-   $$
-   E(a, b) = \int d\lambda \, \rho(\lambda) A(a, \lambda) B(b, \lambda)
-   $$
+Combine expectation values to form the inequality:
+$$
+S = E(a, b) - E(a, b') + E(a', b) + E(a', b')
+$$
 
-2. Combine expectation values to form the inequality:
+Under local hidden variable assumptions, we derive:
 
-   $$
-   S = E(a, b) - E(a, b') + E(a', b) + E(a', b')
-   $$
-
-3. Under local hidden variable assumptions, we derive:
-
-   $$
-   |S| \leq 2
-   $$
+$$
+|S| \leq 2
+$$
 
 
 ### Referances 

--- a/Mathematics_Bells_Inequality.md
+++ b/Mathematics_Bells_Inequality.md
@@ -14,9 +14,18 @@ $$
 $$
 
 This state describes two qubits, where:
-\(|01\rangle\): The first qubit is in state \(|0\rangle\) (e.g., spin down), and the second is in state \(|1\rangle\) (e.g., spin up).
 
-\(|10\rangle\): The first qubit is in state \(|1\rangle\) (spin up), and the second is in state \(|0\rangle\) (spin down).
+$$
+\(|01\rangle\)
+$$
+
+The first qubit is in state $\(|0\rangle\)$ (e.g., spin down), and the second is in state $\(|1\rangle\)$ (e.g., spin up).
+
+$$
+\(|10\rangle\)
+$$
+
+The first qubit is in state $\(|1\rangle\)$ (spin up), and the second is in state $\(|0\rangle\)$ (spin down).
 
 The overall state is a superposition where the particles are perfectly anti-correlated.
 
@@ -28,9 +37,23 @@ $$ E(a, b) = \int d\lambda \, \rho(\lambda) A(a, \lambda) B(b, \lambda) $$
 
 where:
 
-`$A(a, \lambda)$` and `$B(b, \lambda)$` represent measurement outcomes.
+$$
+A(a, \lambda)
+$$
 
-`$\rho(\lambda)$` is the probability distribution of hidden variables.
+and
+
+$$
+B(b, \lambda)
+$$
+
+represent measurement outcomes.
+
+$$
+\rho(\lambda)
+$$ 
+
+is the probability distribution of hidden variables.
 
 ## Derivation
 

--- a/Mathematics_Bells_Inequality.md
+++ b/Mathematics_Bells_Inequality.md
@@ -14,10 +14,10 @@ $$
 $$
 
 This state describes two qubits, where:
-- \(|01\rangle\): The first qubit is in state \( |0\rangle \) (e.g., spin down), and the second is in state \( |1\rangle \) (e.g., spin up).
-- \(|10\rangle\): The first qubit is in state \( |1\rangle \) (spin up), and the second is in state \( |0\rangle \) (spin down).
+- \(|01\rangle\): The first qubit is in state \(|0\rangle\) (e.g., spin down), and the second is in state \(|1\rangle\) (e.g., spin up).
+- \(|10\rangle\): The first qubit is in state \(|1\rangle\) (spin up), and the second is in state \(|0\rangle\) (spin down).
 
-The overall state is a superposition where the particles are perfectly anti-correlated, meaning that if one particle is measured to be \( |0\rangle \), the other will definitely be \( |1\rangle \), and vice versa.
+The overall state is a superposition where the particles are perfectly anti-correlated.
 
 ## Mathematical Derivation of Bell's Inequality
 
@@ -26,23 +26,29 @@ To understand Bell's inequality, consider two entangled particles measured by ob
 $$ E(a, b) = \int d\lambda \, \rho(\lambda) A(a, \lambda) B(b, \lambda) $$
 
 where:
-## Definition of Variables
 - `$A(a, \lambda)$` and `$B(b, \lambda)$` represent measurement outcomes.
-- `$ \rho(\lambda)$` is the probability distribution of hidden variables.
+- `$\rho(\lambda)$` is the probability distribution of hidden variables.
 
 ## Derivation
 
 1. The expectation value of the product of Alice's and Bob's outcomes for a given pair of settings \( (a, b) \) is defined as:
 
-   $$ E(a, b) = \int d\lambda \, \rho(\lambda) A(a, \lambda) B(b, \lambda) $$
+   $$
+   E(a, b) = \int d\lambda \, \rho(\lambda) A(a, \lambda) B(b, \lambda)
+   $$
 
 2. Combine expectation values to form the inequality:
 
-   $$ S = E(a, b) - E(a, b') + E(a', b) + E(a', b') $$
+   $$
+   S = E(a, b) - E(a, b') + E(a', b) + E(a', b')
+   $$
 
 3. Under local hidden variable assumptions, we derive:
 
-   $$ |S| \leq 2 $$
+   $$
+   |S| \leq 2
+   $$
+
 
 ### Referances 
 1. https://cds.cern.ch/record/111654/files/vol1p195-200_001.pdf

--- a/Mathematics_Bells_Inequality.md
+++ b/Mathematics_Bells_Inequality.md
@@ -15,6 +15,7 @@ $$
 
 This state describes two qubits, where:
 \(|01\rangle\): The first qubit is in state \(|0\rangle\) (e.g., spin down), and the second is in state \(|1\rangle\) (e.g., spin up).
+
 \(|10\rangle\): The first qubit is in state \(|1\rangle\) (spin up), and the second is in state \(|0\rangle\) (spin down).
 
 The overall state is a superposition where the particles are perfectly anti-correlated.
@@ -26,17 +27,21 @@ To understand Bell's inequality, consider two entangled particles measured by ob
 $$ E(a, b) = \int d\lambda \, \rho(\lambda) A(a, \lambda) B(b, \lambda) $$
 
 where:
+
 `$A(a, \lambda)$` and `$B(b, \lambda)$` represent measurement outcomes.
+
 `$\rho(\lambda)$` is the probability distribution of hidden variables.
 
 ## Derivation
 
 The expectation value of the product of Alice's and Bob's outcomes for a given pair of settings \( (a, b) \) is defined as:
+
  $$
  E(a, b) = \int d\lambda \, \rho(\lambda) A(a, \lambda) B(b, \lambda)
  $$
 
 Combine expectation values to form the inequality:
+
 $$
 S = E(a, b) - E(a, b') + E(a', b) + E(a', b')
 $$


### PR DESCRIPTION
Summary
- Added a detailed mathematical derivation of Bell's inequality using Markdown and LaTeX.
- Improved document structure with clear headings and formatted equations.